### PR TITLE
Prev next links

### DIFF
--- a/src/components/nav-buttons.tsx
+++ b/src/components/nav-buttons.tsx
@@ -3,6 +3,7 @@ import Chevron from "react-chevron";
 import { Toolbar, ToolbarItem, useToolbarState } from "reakit";
 import { useAppDispatch, useAppSelector } from "../app/hooks";
 import { navActions, nextPrevParentSelector } from "../features/nav/navSlice";
+import { InternalAnchor } from "./links";
 
 export function NavButtons() {
     const toolbar = useToolbarState();
@@ -17,7 +18,7 @@ export function NavButtons() {
         >
             <ToolbarItem
                 {...toolbar}
-                as="a"
+                as={InternalAnchor}
                 href={navTargets.prev?.id || "#"}
                 className="previous-button button"
                 title={
@@ -42,7 +43,7 @@ export function NavButtons() {
             </ToolbarItem>
             <ToolbarItem
                 {...toolbar}
-                as="a"
+                as={InternalAnchor}
                 href={navTargets.up?.id || "#"}
                 title={navTargets.up ? `Up (${navTargets.up.title})` : "Up"}
                 className="up-button button"
@@ -61,7 +62,7 @@ export function NavButtons() {
             </ToolbarItem>
             <ToolbarItem
                 {...toolbar}
-                as="a"
+                as={InternalAnchor}
                 href={navTargets.next?.id || "#"}
                 title={
                     navTargets.next ? `Next (${navTargets.next.title})` : "Next"

--- a/src/components/nav-buttons.tsx
+++ b/src/components/nav-buttons.tsx
@@ -28,7 +28,6 @@ export function NavButtons() {
                 }
                 disabled={!navTargets.prev}
                 onClick={(e: React.MouseEvent) => {
-                    e.preventDefault()
                     if (navTargets.prev) {
                         dispatch(
                             navActions.setCurrentPage(
@@ -49,7 +48,6 @@ export function NavButtons() {
                 className="up-button button"
                 disabled={!navTargets.up}
                 onClick={(e: React.MouseEvent) => {
-                    e.preventDefault()
                     if (navTargets.up) {
                         dispatch(
                             navActions.setCurrentPage(navTargets.up.id || null)
@@ -70,7 +68,6 @@ export function NavButtons() {
                 className="next-button button"
                 disabled={!navTargets.next}
                 onClick={(e: React.MouseEvent) => {
-                    e.preventDefault()
                     if (navTargets.next) {
                         dispatch(
                             navActions.setCurrentPage(

--- a/src/components/nav-buttons.tsx
+++ b/src/components/nav-buttons.tsx
@@ -26,7 +26,8 @@ export function NavButtons() {
                         : "Previous"
                 }
                 disabled={!navTargets.prev}
-                onClick={() => {
+                onClick={(e: React.MouseEvent) => {
+                    e.preventDefault()
                     if (navTargets.prev) {
                         dispatch(
                             navActions.setCurrentPage(
@@ -46,7 +47,8 @@ export function NavButtons() {
                 title={navTargets.up ? `Up (${navTargets.up.title})` : "Up"}
                 className="up-button button"
                 disabled={!navTargets.up}
-                onClick={() => {
+                onClick={(e: React.MouseEvent) => {
+                    e.preventDefault()
                     if (navTargets.up) {
                         dispatch(
                             navActions.setCurrentPage(navTargets.up.id || null)
@@ -66,7 +68,8 @@ export function NavButtons() {
                 }
                 className="next-button button"
                 disabled={!navTargets.next}
-                onClick={() => {
+                onClick={(e: React.MouseEvent) => {
+                    e.preventDefault()
                     if (navTargets.next) {
                         dispatch(
                             navActions.setCurrentPage(

--- a/src/components/page-footer.tsx
+++ b/src/components/page-footer.tsx
@@ -23,7 +23,6 @@ export function PageFooter() {
                 }
                 disabled={!navTargets.prev}
                 onClick={(e: React.MouseEvent) => {
-                    e.preventDefault()
                     if (navTargets.prev) {
                         dispatch(
                             navActions.setCurrentPage(
@@ -61,7 +60,6 @@ export function PageFooter() {
                 className="next-button button"
                 disabled={!navTargets.next}
                 onClick={(e: React.MouseEvent) => {
-                    e.preventDefault()
                     if (navTargets.next) {
                         dispatch(
                             navActions.setCurrentPage(

--- a/src/components/page-footer.tsx
+++ b/src/components/page-footer.tsx
@@ -21,7 +21,8 @@ export function PageFooter() {
                         : "Previous"
                 }
                 disabled={!navTargets.prev}
-                onClick={() => {
+                onClick={(e: React.MouseEvent) => {
+                    e.preventDefault()
                     if (navTargets.prev) {
                         dispatch(
                             navActions.setCurrentPage(
@@ -58,7 +59,8 @@ export function PageFooter() {
                 }
                 className="next-button button"
                 disabled={!navTargets.next}
-                onClick={() => {
+                onClick={(e: React.MouseEvent) => {
+                    e.preventDefault()
                     if (navTargets.next) {
                         dispatch(
                             navActions.setCurrentPage(

--- a/src/components/page-footer.tsx
+++ b/src/components/page-footer.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { ToolbarItem, useToolbarState } from "reakit";
 import { useAppDispatch, useAppSelector } from "../app/hooks";
 import { navActions, nextPrevParentSelector } from "../features/nav/navSlice";
+import { InternalAnchor } from "./links";
 
 export function PageFooter() {
     const toolbar = useToolbarState();
@@ -12,7 +13,7 @@ export function PageFooter() {
         <div className="ptx-content-footer">
             <ToolbarItem
                 {...toolbar}
-                as="a"
+                as={InternalAnchor}
                 href={navTargets.prev?.id || "#"}
                 className="previous-button button"
                 title={
@@ -37,7 +38,7 @@ export function PageFooter() {
             </ToolbarItem>
             <ToolbarItem
                 {...toolbar}
-                as="a"
+                as={InternalAnchor}
                 href={"#"}
                 title={"Top"}
                 className="top-button button"
@@ -52,7 +53,7 @@ export function PageFooter() {
             </ToolbarItem>
             <ToolbarItem
                 {...toolbar}
-                as="a"
+                as={InternalAnchor}
                 href={navTargets.next?.id || "#"}
                 title={
                     navTargets.next ? `Next (${navTargets.next.title})` : "Next"

--- a/src/components/toc/index.tsx
+++ b/src/components/toc/index.tsx
@@ -66,7 +66,7 @@ function TocEntry({ entry }: { entry: TocEntryType }) {
         }
     }, [entry.title]);
 
-    const shouldRenderCodeNumber = !!entry.codeNumber && (entry.level || 0) < 2;
+    const shouldRenderCodeNumber = !!entry.codeNumber && (entry.level || 0) < 3;
 
     // We never render divisions with empty headers.
     const children = entry.children


### PR DESCRIPTION
The Prev/UP/Next links now function  properly, and the top level is numbered in the TOC.

Note that the "level" in the TOC is one larger than I expected.  Will submit an issue.